### PR TITLE
Fix user context report modal

### DIFF
--- a/src/main/kotlin/de/miraculixx/ghg_bot/commands/ReportCommand.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/commands/ReportCommand.kt
@@ -45,18 +45,7 @@ class ReportCommand : SlashCommandEvent {
 
     override suspend fun triggerUserApp(it: UserContextInteractionEvent) {
         val target = it.interaction.targetMember ?: return
-        it.replyModal("TICKET-REPORT", "Nutzer Melden") {
-            label("Nutzer Tag") {
-                child = TextInput("TAG", TextInputStyle.SHORT, value = target.user.asTag) {
-                    required = true
-                    requiredLength = 6..100
-                }
-            }
-            label("Nutzer ID") {
-                child = TextInput("ID", TextInputStyle.SHORT, value = target.id, requiredLength = 17..20) {
-                    required = true
-                }
-            }
+        it.replyModal("TICKET-REPORT-USER:${target.id}", "${target.user.name} melden") {
             label("Grund") {
                 child = TextInput("CONTENT", TextInputStyle.PARAGRAPH, placeholder = "Warum möchtest du den Nutzer melden?") {
                     required = true

--- a/src/main/kotlin/de/miraculixx/ghg_bot/commands/ReportCommand.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/commands/ReportCommand.kt
@@ -1,8 +1,10 @@
 package de.miraculixx.ghg_bot.commands
 
+import de.miraculixx.ghg_bot.modules.tickets.TicketModalHandler
 import de.miraculixx.ghg_bot.modules.user_moderation.MessageReport
 import de.miraculixx.ghg_bot.modules.user_moderation.UserModerationManager
 import de.miraculixx.ghg_bot.utils.entities.SlashCommandEvent
+import dev.minn.jda.ktx.coroutines.await
 import dev.minn.jda.ktx.interactions.components.TextInput
 import dev.minn.jda.ktx.interactions.components.replyModal
 import dev.minn.jda.ktx.messages.reply_
@@ -11,9 +13,7 @@ import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionE
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent
 import java.time.Duration
-import java.time.Instant
 import java.time.OffsetDateTime
-import java.util.UUID
 
 class ReportCommand : SlashCommandEvent {
     override suspend fun trigger(it: SlashCommandInteractionEvent) {
@@ -24,10 +24,10 @@ class ReportCommand : SlashCommandEvent {
         val member = it.member ?: return
         val message = it.interaction.target
 
-        val history = it.messageChannel.getHistoryBefore(message, 10).complete().retrievedHistory.asReversed()
+        val history = it.messageChannel.getHistoryBefore(message, 10).await().retrievedHistory.asReversed()
         val report = MessageReport(member, message, "", history.toSet())
         UserModerationManager.cases[report.uuid] = report
-        val offset = Duration.between(message.timeCreated, OffsetDateTime.now());
+        val offset = Duration.between(message.timeCreated, OffsetDateTime.now())
         if (offset.toDays() >= 7) {
             it.reply_("```diff\n- Die Nachricht ist zu alt um gemeldet zu werden!```", ephemeral = true).queue()
             return
@@ -45,15 +45,7 @@ class ReportCommand : SlashCommandEvent {
 
     override suspend fun triggerUserApp(it: UserContextInteractionEvent) {
         val target = it.interaction.targetMember ?: return
-        it.replyModal("TICKET-REPORT-USER:${target.id}", "${target.user.name} melden") {
-            label("Grund") {
-                child = TextInput("CONTENT", TextInputStyle.PARAGRAPH, placeholder = "Warum möchtest du den Nutzer melden?") {
-                    required = true
-                    requiredLength = 50..4000
-                }
-            }
-        }.queue()
+        it.replyModal(TicketModalHandler.getUserReportModal(target.idLong)).queue()
     }
-
 
 }

--- a/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketDropDownHandler.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketDropDownHandler.kt
@@ -3,25 +3,17 @@ package de.miraculixx.ghg_bot.modules.tickets
 import de.miraculixx.ghg_bot.utils.cache.embedAd
 import de.miraculixx.ghg_bot.utils.cache.embedApplication
 import de.miraculixx.ghg_bot.utils.entities.DropDownEvent
-import dev.minn.jda.ktx.interactions.components.EntitySelectMenu
-import dev.minn.jda.ktx.interactions.components.Label
-import dev.minn.jda.ktx.interactions.components.StringSelectMenu
 import dev.minn.jda.ktx.interactions.components.TextInput
 import dev.minn.jda.ktx.interactions.components.button
-import dev.minn.jda.ktx.interactions.components.option
 import dev.minn.jda.ktx.interactions.components.replyModal
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.reply_
-import net.dv8tion.jda.api.components.ModalTopLevelComponent
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.ButtonStyle
-import net.dv8tion.jda.api.components.label.LabelChildComponent
-import net.dv8tion.jda.api.components.selections.EntitySelectMenu
 import net.dv8tion.jda.api.components.selections.StringSelectMenu
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.events.interaction.component.GenericSelectMenuInteractionEvent
-import net.dv8tion.jda.api.modals.Modal
 
 class TicketDropDownHandler : DropDownEvent {
     private val reportInfo = Embed {
@@ -55,32 +47,7 @@ class TicketDropDownHandler : DropDownEvent {
             "WERBUNG" -> it.reply_(embeds = listOf(embedAd), ephemeral = true).queue()
             "BEWERBUNG" -> it.reply_(embeds = listOf(embedApplication), ephemeral = true).queue()
             "UNBAN" -> it.reply_(embeds = listOf(unbanInfo), components = listOf(ActionRow.of(unbanButton)), ephemeral = true).queue()
-            "MELDEN" -> it.replyModal("TICKET-REPORT", "Nutzer melden") {
-                label("Der Nutzer") {
-                    child = EntitySelectMenu("USER", listOf(EntitySelectMenu.SelectTarget.USER))
-                }
-
-                label("Grund & Nachweis") {
-                    description = "Erkläre so gut wie möglich, wie der Nutzer die Regeln bricht! (Datei Nachweise ins Ticket hochladen)"
-                    child = TextInput("CONTENT", TextInputStyle.PARAGRAPH, placeholder = "Der Nutzer macht...", requiredLength = 50..2000)
-                }
-
-                label("Regelbruch Art") {
-                    child = StringSelectMenu("TYPE") {
-                        option("Scam / Steam Report / Phishing", "SPAM", emoji = Emoji.fromFormatted("\uD83C\uDF10"))
-                        option("Voice Channel", "VOICE", emoji = Emoji.fromFormatted("\uD83C\uDF99\uFE0F"))
-                        option("Server Chat", "CHAT", emoji = Emoji.fromFormatted("\uD83D\uDCDD"))
-                        option("Sonstiges", "OTHER", "Reports in dieser Kategorie können länger dauern")
-                    }
-                }
-
-                label("Nachweis Vorhanden?") {
-                    child = StringSelectMenu("EVIDENCE") {
-                        option("Ich hab einen Link beigelegt oder lade es gleich ins Ticket!", "YES", "Voice Channel: Video - Text/User: Screenshots", emoji = Emoji.fromFormatted("✅"))
-                        option("Nein, habe nichts", "NO", "Leider können wir ohne Nachweise nicht viel machen. Andere Nutzer als Zeugen zählen nicht", emoji = Emoji.fromFormatted("❌"))
-                    }
-                }
-            }.queue()
+            "MELDEN" -> it.replyModal(TicketModalHandler.getUserReportModal(null)).queue()
             "SONSTIGES" -> it.replyModal("TICKET-OTHER", "Neues Ticket") {
                 label("Deine Nachricht") {
                     child = TextInput("CONTENT", TextInputStyle.PARAGRAPH, placeholder = "Mit dieser Nachricht beginnt das Ticket") {

--- a/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketModalHandler.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketModalHandler.kt
@@ -37,8 +37,21 @@ object TicketModalHandler : ModalEvent {
         if (channel !is TextChannel) return
         println("Modal: ${it.modalId} by ${member.user.name} in channel ${channel.name}")
 
-        when (it.modalId) {
-            "TICKET-REPORT" -> {
+        when {
+            it.modalId.startsWith("TICKET-REPORT-USER:") -> {
+                val reportedID = it.modalId.substringAfterLast(':')
+                val reported = it.guild?.getMemberById(reportedID)
+                if (reported == null) {
+                    hook.editMessage(content = "```diff\n- Der Nutzer ist nicht mehr auf diesem Server und kann daher nicht gemeldet werden!```").queue()
+                    return
+                }
+
+                member.createTicket(TicketType.REPORT, hook) { thread ->
+                    thread.setupReportTicket(member, reported, message, "Direkte Nutzermeldung")
+                }
+            }
+
+            it.modalId == "TICKET-REPORT" -> {
                 val type = it.getValue("TYPE")?.asStringList?.firstOrNull() ?: "Nicht angegeben"
                 if (type == "SPAM") {
                     hook.editMessage(content = "## Vielen Dank für die Meldung\n" +
@@ -61,7 +74,7 @@ object TicketModalHandler : ModalEvent {
                 }
             }
 
-            "TICKET-OTHER" -> member.createTicket(TicketType.OTHER, hook) { thread ->
+            it.modalId == "TICKET-OTHER" -> member.createTicket(TicketType.OTHER, hook) { thread ->
                 thread.setupOtherTicket(member, message)
             }
 

--- a/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketModalHandler.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/modules/tickets/TicketModalHandler.kt
@@ -6,8 +6,13 @@ import de.miraculixx.ghg_bot.utils.cache.ticketReportRole
 import de.miraculixx.ghg_bot.utils.entities.ModalEvent
 import dev.minn.jda.ktx.generics.getChannel
 import dev.minn.jda.ktx.interactions.components.Container
+import dev.minn.jda.ktx.interactions.components.EntitySelectMenu
+import dev.minn.jda.ktx.interactions.components.Modal
+import dev.minn.jda.ktx.interactions.components.StringSelectMenu
+import dev.minn.jda.ktx.interactions.components.TextInput
 import dev.minn.jda.ktx.interactions.components.Thumbnail
 import dev.minn.jda.ktx.interactions.components.button
+import dev.minn.jda.ktx.interactions.components.option
 import dev.minn.jda.ktx.messages.Embed
 import dev.minn.jda.ktx.messages.editMessage
 import dev.minn.jda.ktx.messages.send
@@ -21,6 +26,8 @@ import net.dv8tion.jda.api.entities.emoji.Emoji
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.ButtonStyle
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.interactions.InteractionHook
 
 object TicketModalHandler : ModalEvent {
@@ -37,21 +44,8 @@ object TicketModalHandler : ModalEvent {
         if (channel !is TextChannel) return
         println("Modal: ${it.modalId} by ${member.user.name} in channel ${channel.name}")
 
-        when {
-            it.modalId.startsWith("TICKET-REPORT-USER:") -> {
-                val reportedID = it.modalId.substringAfterLast(':')
-                val reported = it.guild?.getMemberById(reportedID)
-                if (reported == null) {
-                    hook.editMessage(content = "```diff\n- Der Nutzer ist nicht mehr auf diesem Server und kann daher nicht gemeldet werden!```").queue()
-                    return
-                }
-
-                member.createTicket(TicketType.REPORT, hook) { thread ->
-                    thread.setupReportTicket(member, reported, message, "Direkte Nutzermeldung")
-                }
-            }
-
-            it.modalId == "TICKET-REPORT" -> {
+        when (it.modalId) {
+            "TICKET-REPORT" -> {
                 val type = it.getValue("TYPE")?.asStringList?.firstOrNull() ?: "Nicht angegeben"
                 if (type == "SPAM") {
                     hook.editMessage(content = "## Vielen Dank für die Meldung\n" +
@@ -61,7 +55,8 @@ object TicketModalHandler : ModalEvent {
                 }
                 val reported = it.getValue("USER")?.asMentions?.members?.firstOrNull()
                 if (reported == null) {
-                    hook.editMessage(content = "```diff\n- Der Nutzer muss auf diesem Server sein, damit du ihn melden kannst!```").queue()
+                    hook.editMessage(content = "```diff\n- Der Nutzer muss auf diesem Server sein, damit du ihn melden kannst!\n" +
+                            "Möglicherweise haben wir ihn bereits gebannt oder er ist von selbst gegangen.```").queue()
                     return
                 }
                 val evidence = it.getValue("EVIDENCE")?.asStringList?.firstOrNull() == "YES"
@@ -74,7 +69,7 @@ object TicketModalHandler : ModalEvent {
                 }
             }
 
-            it.modalId == "TICKET-OTHER" -> member.createTicket(TicketType.OTHER, hook) { thread ->
+            "TICKET-OTHER" -> member.createTicket(TicketType.OTHER, hook) { thread ->
                 thread.setupOtherTicket(member, message)
             }
 
@@ -138,4 +133,36 @@ object TicketModalHandler : ModalEvent {
         )).useComponentsV2().queue()
         send(message).queue()
     }
+
+    //
+    // Shared states
+    //
+    fun getUserReportModal(target: Long?) = Modal("TICKET-REPORT", "Nutzer melden") {
+            label("Der Nutzer") {
+                child = EntitySelectMenu("USER", listOf(EntitySelectMenu.SelectTarget.USER)) {
+                    target?.let { setDefaultValues(EntitySelectMenu.DefaultValue.user(it)) }
+                }
+            }
+
+            label("Grund & Nachweis") {
+                description = "Erkläre so gut wie möglich, wie der Nutzer die Regeln bricht! (Datei Nachweise ins Ticket hochladen)"
+                child = TextInput("CONTENT", TextInputStyle.PARAGRAPH, placeholder = "Der Nutzer macht...", requiredLength = 50..2000)
+            }
+
+            label("Regelbruch Art") {
+                child = StringSelectMenu("TYPE") {
+                    option("Scam / Steam Report / Phishing", "SPAM", emoji = Emoji.fromFormatted("\uD83C\uDF10"))
+                    option("Voice Channel", "VOICE", emoji = Emoji.fromFormatted("\uD83C\uDF99\uFE0F"))
+                    option("Server Chat", "CHAT", emoji = Emoji.fromFormatted("\uD83D\uDCDD"))
+                    option("Sonstiges", "OTHER", "Reports in dieser Kategorie können länger dauern")
+                }
+            }
+
+            label("Nachweis Vorhanden?") {
+                child = StringSelectMenu("EVIDENCE") {
+                    option("Ich hab einen Link beigelegt oder lade es gleich ins Ticket!", "YES", "Voice Channel: Video - Text/User: Screenshots", emoji = Emoji.fromFormatted("✅"))
+                    option("Nein, habe nichts", "NO", "Leider können wir ohne Nachweise nicht viel machen. Andere Nutzer als Zeugen zählen nicht", emoji = Emoji.fromFormatted("❌"))
+                }
+            }
+        }
 }


### PR DESCRIPTION
## Was wurde geändert?

Ich habe den bestehenden Nutzer-Report über Rechtsklick → Apps → „Melde Nutzer“ repariert.

Das Modal enthält jetzt nur noch das Feld für den Meldegrund. Die ID des ausgewählten Nutzers wird intern über die Modal-ID weitergegeben und beim Absenden serverseitig aufgelöst.

## Warum?

Der bisherige Ablauf hat Felder gesendet, die der Ticket-Handler nicht erwartet hat. Dadurch konnte der gemeldete Nutzer nicht ermittelt und kein Report-Ticket erstellt werden.

Die Änderung verwendet weiterhin das bestehende Ticket-System und erstellt keine zusätzlichen Discord-Channels oder neuen Systeme.

Getestet mit `gradlew compileJava` – Build erfolgreich.