### PR TITLE
Fix: Set channel types for voice join and minimum warns to 0

### DIFF
--- a/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
@@ -11,6 +11,7 @@ import dev.minn.jda.ktx.interactions.commands.option
 import dev.minn.jda.ktx.interactions.commands.subcommand
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
@@ -132,19 +133,17 @@ object SlashCommandManager {
             Command("warnings", "Verwalte Warnungen") {
                 subcommand("amount", "Erhalte die Menge an Warnungen") {
                     defaultPermissions = DefaultMemberPermissions.DISABLED
-                    addOption(OptionType.USER, "user", "Welcher Nutzer?", true)
+                    option<User>("user", "Welcher Nutzer?", true)
                 }
                 subcommand("warn", "Warne einen Nutzer") {
                     defaultPermissions = DefaultMemberPermissions.DISABLED
-                    addOption(OptionType.USER, "user", "Welcher Nutzer?", true)
+                    option<User>("user", "Welcher Nutzer?", true)
                     option<String>("reason", "Warum?", true)
                 }
                 subcommand("set-warns", "Ändere Warnungsanzahl") {
                     defaultPermissions = DefaultMemberPermissions.DISABLED
-                    addOption(OptionType.USER, "user", "Welcher Nutzer?", true)
-                    addOptions(
-                        OptionData(OptionType.INTEGER, "amount", "Wie viele?", true).setMinValue(0)
-                    )
+                    option<User>( "user", "Welcher Nutzer?", true)
+                    option<Int>("amount", "Wie viele?", true) { setMinValue(0) }
                 }
             },
             Command("message", "Send and handle bot messages") {
@@ -156,10 +155,7 @@ object SlashCommandManager {
             Command("voice", "...") {
                 defaultPermissions = DefaultMemberPermissions.DISABLED
                 subcommand("join", "Join") {
-                    addOptions(
-                        OptionData(OptionType.CHANNEL, "channel", "Channel", true)
-                            .setChannelTypes(ChannelType.VOICE, ChannelType.STAGE)
-                    )
+                    option<VoiceChannel>("channel", "Channel", true)
                 }
             },
             Command("verify", "Verifiziere dich, um mehrere Links oder Anhänge senden zu können"),

--- a/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
@@ -12,7 +12,6 @@ import dev.minn.jda.ktx.interactions.commands.subcommand
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.User
-import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -20,9 +19,7 @@ import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEven
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
-import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
-import net.dv8tion.jda.api.interactions.commands.build.OptionData
 
 object SlashCommandManager {
     private val commands = mapOf(

--- a/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
+++ b/src/main/kotlin/de/miraculixx/ghg_bot/utils/manager/SlashCommandManager.kt
@@ -11,6 +11,7 @@ import dev.minn.jda.ktx.interactions.commands.option
 import dev.minn.jda.ktx.interactions.commands.subcommand
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -20,6 +21,7 @@ import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
 
 object SlashCommandManager {
     private val commands = mapOf(
@@ -140,7 +142,9 @@ object SlashCommandManager {
                 subcommand("set-warns", "Ändere Warnungsanzahl") {
                     defaultPermissions = DefaultMemberPermissions.DISABLED
                     addOption(OptionType.USER, "user", "Welcher Nutzer?", true)
-                    option<Int>("amount", "Wie viele?", true)
+                    addOptions(
+                        OptionData(OptionType.INTEGER, "amount", "Wie viele?", true).setMinValue(0)
+                    )
                 }
             },
             Command("message", "Send and handle bot messages") {
@@ -152,7 +156,10 @@ object SlashCommandManager {
             Command("voice", "...") {
                 defaultPermissions = DefaultMemberPermissions.DISABLED
                 subcommand("join", "Join") {
-                    option<VoiceChannel>("channel", "Channel", true)
+                    addOptions(
+                        OptionData(OptionType.CHANNEL, "channel", "Channel", true)
+                            .setChannelTypes(ChannelType.VOICE, ChannelType.STAGE)
+                    )
                 }
             },
             Command("verify", "Verifiziere dich, um mehrere Links oder Anhänge senden zu können"),


### PR DESCRIPTION
This pull request updates the way options are defined for certain slash commands in the `SlashCommandManager`, improving type safety and validation for user inputs. The main changes involve switching from generic option definitions to using `OptionData` for more precise control, such as setting minimum values and restricting channel types.

**Slash command option improvements:**

* Changed the "amount" option in the "set-warns" subcommand to use `OptionData` with `OptionType.INTEGER` and a minimum value of 0, ensuring users cannot set negative warning amounts.
* Updated the "channel" option in the "voice join" subcommand to use `OptionData` with `OptionType.CHANNEL`, restricting selection to only voice and stage channels for better input validation.

**Dependency updates:**

* Added imports for `ChannelType` and `OptionData` to support the new option definitions. [[1]](diffhunk://#diff-8877bdd15cb0f1fc94a781d2ba2370be6471f0da2683690a6f9ddc3487821efbR14) [[2]](diffhunk://#diff-8877bdd15cb0f1fc94a781d2ba2370be6471f0da2683690a6f9ddc3487821efbR24)

~ Thanks Copilot